### PR TITLE
Update ProDiff.py

### DIFF
--- a/inference/ProDiff.py
+++ b/inference/ProDiff.py
@@ -10,6 +10,10 @@ from functools import partial
 
 class ProDiffInfer(BaseTTSInfer):
     def build_model(self):
+        if 'f0_mean' not in hparams:
+            hparams['f0_mean'] = 1.0
+        if 'f0_std' not in hparams:
+            hparams['f0_std'] = 1.0
         f0_stats_fn = f'{hparams["binary_data_dir"]}/train_f0s_mean_std.npy'
         if os.path.exists(f0_stats_fn):
             hparams['f0_mean'], hparams['f0_std'] = np.load(f0_stats_fn)


### PR DESCRIPTION
The key 'f0_std' is used in the code with the dictionary 'hparams', but this key cannot be found in the dictionary 'hparams', resulting in a KeyError error.

The reason is that the 'f0_std' key-value pair in the 'hparams' dictionary was not properly set in the previous code, causing an error in the following code segment in the 'build_model()' function of the 'ProDiffInfer' class.

The solution is to ensure that the 'f0_std' key-value pair in the 'hparams' dictionary is correctly set in the previous code, or add a default value in the code.
